### PR TITLE
stop ajaxify opening local assets

### DIFF
--- a/public/src/ajaxify.js
+++ b/public/src/ajaxify.js
@@ -349,6 +349,10 @@ $(document).ready(function () {
 				return;
 			}
 
+			if (this.href.test(/^\/(assets|plugins)/i)) {
+				return;
+			}
+
 			var internalLink = utils.isInternalURI(this, window.location, RELATIVE_PATH);
 
 			var process = function () {


### PR DESCRIPTION
Ajaxify was having problems that not all local files are to be forcefully opened :)

Signed-off-by: Krzysztof Antoszek <krzysztof@antoszek.net>